### PR TITLE
Fix cache write-on-read, add crop-pool backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,42 @@
 # CHANGELOG
 
 
+## v0.4.0 (2026-07-27)
+
+### Bug Fixes
+
+- Return captured frame from fetch_video_frame_async
+  ([`c84318a`](https://github.com/mbari-org/skimmer/commit/c84318a6d5b392243dc26cfc9d4fd8686919bc34))
+
+fetch_video_frame_async cached the Beholder-captured frame but never returned it, so
+  generate_crop_async would call .crop() on None for any async-path video request. Return the image,
+  matching the sync fetch_video_frame twin.
+
+### Features
+
+- Pre-validate crop parameters before fetching image/video frames
+  ([`7d81702`](https://github.com/mbari-org/skimmer/commit/7d817025d8a8ce7915d4cf34e9a009509b1cbed8))
+
+Validate the URL and crop coordinates (non-negative, right>left, bottom>top, ms>=0) up front in
+  Skimmer.generate_crop/_async, before any cache lookup or network/frame fetch, and surface bad
+  input as a descriptive 400 via InvalidCropParametersError in both the FastAPI and Flask handlers.
+
+### Performance Improvements
+
+- Use threaded gunicorn workers and a pooled HTTP client under load
+  ([`068bb07`](https://github.com/mbari-org/skimmer/commit/068bb075eeb8c84cc355e242567b55d574151c7d))
+
+Sync gunicorn workers handled one request at a time each, capping concurrency at APP_WORKERS
+  regardless of how I/O-bound a request is (upstream fetch, disk cache). Switch to gthread workers
+  with a tunable APP_THREADS so each worker can overlap I/O waits across threads.
+
+Since the in-memory image LRUCache isn't thread-safe, guard it with a lock now that concurrent
+  access within a worker is possible.
+
+Also reuse a single httpx.Client (with explicit timeouts) across sync image fetches instead of
+  opening a new connection per request, and add a timeout to the async fetch path.
+
+
 ## v0.3.2 (2026-07-15)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skimmer"
-version = "0.3.2"
+version = "0.4.0"
 description = "ROI cropping service"
 readme = "README.md"
 authors = [

--- a/src/skimmer/api/fastapi/__init__.py
+++ b/src/skimmer/api/fastapi/__init__.py
@@ -1,6 +1,7 @@
 import random
 from sys import version as python_version
 
+import httpx
 from fastapi import FastAPI
 from psutil import cpu_count, virtual_memory
 
@@ -71,6 +72,16 @@ class SkimmerFastAPI:
             )
             response.headers["Retry-After"] = str(_retry_after_seconds())
             return response
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 503:
+                response = ErrorResponse(
+                    "Beholder is at capture capacity. Please retry shortly.", status=503
+                )
+                response.headers["Retry-After"] = e.response.headers.get(
+                    "Retry-After", str(_retry_after_seconds())
+                )
+                return response
+            return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
         except Exception as e:
             return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
 

--- a/src/skimmer/api/fastapi/__init__.py
+++ b/src/skimmer/api/fastapi/__init__.py
@@ -1,9 +1,11 @@
+import random
 from sys import version as python_version
 
 from fastapi import FastAPI
 from psutil import cpu_count, virtual_memory
 
 from skimmer.api.fastapi.models import Error, HealthStatus
+from skimmer.backpressure import Saturated, StaleWork
 from skimmer.core import Skimmer
 from skimmer.constants import APP_DESCRIPTION, APP_NAME, APP_VERSION
 from skimmer.exceptions import (
@@ -12,6 +14,11 @@ from skimmer.exceptions import (
     InvalidCropParametersError,
 )
 from skimmer.api.fastapi.responses import ErrorResponse, ImageResponse, JSONResponse
+
+
+def _retry_after_seconds() -> float:
+    """Jittered so clients shed by the same burst don't all retry in the same instant."""
+    return round(random.uniform(1.0, 3.0), 1)
 
 
 class SkimmerFastAPI:
@@ -27,7 +34,13 @@ class SkimmerFastAPI:
         self._configure()
 
     async def crop(
-        self, url: str, left: int, top: int, right: int, bottom: int, ms: int = 0
+        self,
+        url: str,
+        left: int,
+        top: int,
+        right: int,
+        bottom: int,
+        ms: int = 0,
     ) -> ImageResponse:
         """
         Crop the image based on the provided URL and coordinates.
@@ -46,6 +59,18 @@ class SkimmerFastAPI:
             return ErrorResponse(str(e))
         except BeholderNotConfiguredError as e:
             return ErrorResponse(str(e), status=500)
+        except Saturated:
+            response = ErrorResponse(
+                "The server is at crop capacity. Please retry shortly.", status=503
+            )
+            response.headers["Retry-After"] = str(_retry_after_seconds())
+            return response
+        except StaleWork:
+            response = ErrorResponse(
+                "Your request waited too long to start. Please retry shortly.", status=503
+            )
+            response.headers["Retry-After"] = str(_retry_after_seconds())
+            return response
         except Exception as e:
             return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
 

--- a/src/skimmer/api/flask/__init__.py
+++ b/src/skimmer/api/flask/__init__.py
@@ -1,6 +1,7 @@
 import random
 from sys import version as python_version
 
+import httpx
 from flask import Flask, request
 from psutil import cpu_count, virtual_memory
 
@@ -77,6 +78,16 @@ class SkimmerFlaskAPI:
             )
             response.headers["Retry-After"] = str(_retry_after_seconds())
             return response
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 503:
+                response = ErrorResponse(
+                    "Beholder is at capture capacity. Please retry shortly.", status=503
+                )
+                response.headers["Retry-After"] = e.response.headers.get(
+                    "Retry-After", str(_retry_after_seconds())
+                )
+                return response
+            return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
         except Exception as e:
             return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
 

--- a/src/skimmer/api/flask/__init__.py
+++ b/src/skimmer/api/flask/__init__.py
@@ -1,8 +1,10 @@
+import random
 from sys import version as python_version
 
 from flask import Flask, request
 from psutil import cpu_count, virtual_memory
 
+from skimmer.backpressure import Saturated, StaleWork
 from skimmer.core import Skimmer
 from skimmer.constants import APP_DESCRIPTION, APP_NAME, APP_VERSION
 from skimmer.exceptions import (
@@ -11,6 +13,11 @@ from skimmer.exceptions import (
     InvalidCropParametersError,
 )
 from skimmer.api.flask.responses import ErrorResponse, ImageResponse, JSONResponse
+
+
+def _retry_after_seconds() -> float:
+    """Jittered so clients shed by the same burst don't all retry in the same instant."""
+    return round(random.uniform(1.0, 3.0), 1)
 
 
 class SkimmerFlaskAPI:
@@ -58,6 +65,18 @@ class SkimmerFlaskAPI:
             return ErrorResponse(str(e))
         except BeholderNotConfiguredError as e:
             return ErrorResponse(str(e), status=500)
+        except Saturated:
+            response = ErrorResponse(
+                "The server is at crop capacity. Please retry shortly.", status=503
+            )
+            response.headers["Retry-After"] = str(_retry_after_seconds())
+            return response
+        except StaleWork:
+            response = ErrorResponse(
+                "Your request waited too long to start. Please retry shortly.", status=503
+            )
+            response.headers["Retry-After"] = str(_retry_after_seconds())
+            return response
         except Exception as e:
             return ErrorResponse(f"An unexpected error occurred: {str(e)}", status=500)
 

--- a/src/skimmer/backpressure.py
+++ b/src/skimmer/backpressure.py
@@ -105,7 +105,7 @@ class AsyncBoundedGate:
             timeout = self._max_wait_seconds if self._max_wait_seconds > 0 else None
             try:
                 await asyncio.wait_for(self._semaphore.acquire(), timeout=timeout)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 raise StaleWork(time.monotonic() - start) from None
             return time.monotonic() - start
         finally:

--- a/src/skimmer/backpressure.py
+++ b/src/skimmer/backpressure.py
@@ -1,0 +1,118 @@
+"""Bounded concurrency gate for the crop-generation path.
+
+Mirrors Beholder's ``BoundedExecutor`` (added in beholder 0.3.1) so both
+services shed load the same way under overload: saturation is reported
+immediately rather than queuing without limit, and a caller that waited past
+``max_wait_seconds`` for a slot is told so rather than served late.
+
+Skimmer's own request-handling concurrency (gunicorn gthreads for Flask, the
+asyncio event loop for FastAPI) already *is* the pool of workers -- unlike
+Beholder, which needed a pool separate from Vert.x's IO threads to bound
+concurrent ffmpeg subprocesses. So there are two gate implementations here,
+one per concurrency model, rather than a single worker-pool abstraction:
+
+- ``BoundedGate`` (sync, for Flask): a ``threading.Semaphore`` plus a bounded
+  count of waiters.
+- ``AsyncBoundedGate`` (async, for FastAPI): the ``asyncio`` equivalent.
+
+Both raise :class:`Saturated` immediately if the waiting queue is already
+full, or :class:`StaleWork` if the wait exceeded ``max_wait_seconds``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+
+class Saturated(Exception):
+    """Raised immediately when the gate's waiting queue is already full."""
+
+
+class StaleWork(Exception):
+    """Raised when a caller waited longer than max_wait_seconds for a slot."""
+
+    def __init__(self, waited_seconds: float) -> None:
+        super().__init__(f"Waited {waited_seconds:.1f}s for a slot")
+        self.waited_seconds = waited_seconds
+
+
+class BoundedGate:
+    """Sync (thread-based) bounded concurrency gate, for Flask/gthread workers."""
+
+    def __init__(self, slots: int, queue_size: int, max_wait_seconds: float) -> None:
+        if slots <= 0:
+            raise ValueError(f"slots must be > 0, got {slots}")
+        if queue_size <= 0:
+            raise ValueError(f"queue_size must be > 0, got {queue_size}")
+        self._semaphore = threading.Semaphore(slots)
+        self._queue_size = queue_size
+        self._waiting = 0
+        self._waiting_lock = threading.Lock()
+        self._max_wait_seconds = max_wait_seconds
+
+    def acquire(self) -> float:
+        """Reserve a slot, blocking (up to max_wait_seconds) if none is free.
+
+        Returns:
+            Seconds waited for the slot.
+
+        Raises:
+            Saturated: The waiting queue is already full.
+            StaleWork: The wait exceeded max_wait_seconds; no slot was reserved.
+        """
+        with self._waiting_lock:
+            if self._waiting >= self._queue_size:
+                raise Saturated
+            self._waiting += 1
+        try:
+            start = time.monotonic()
+            timeout = self._max_wait_seconds if self._max_wait_seconds > 0 else None
+            acquired = self._semaphore.acquire(timeout=timeout)
+            waited = time.monotonic() - start
+            if not acquired:
+                raise StaleWork(waited)
+            return waited
+        finally:
+            with self._waiting_lock:
+                self._waiting -= 1
+
+    def release(self) -> None:
+        self._semaphore.release()
+
+
+class AsyncBoundedGate:
+    """Async (asyncio-based) bounded concurrency gate, for FastAPI/uvicorn."""
+
+    def __init__(self, slots: int, queue_size: int, max_wait_seconds: float) -> None:
+        if slots <= 0:
+            raise ValueError(f"slots must be > 0, got {slots}")
+        if queue_size <= 0:
+            raise ValueError(f"queue_size must be > 0, got {queue_size}")
+        self._semaphore = asyncio.Semaphore(slots)
+        self._queue_size = queue_size
+        self._waiting = 0
+        self._max_wait_seconds = max_wait_seconds
+
+    async def acquire(self) -> float:
+        """Async equivalent of :meth:`BoundedGate.acquire`."""
+        if self._waiting >= self._queue_size:
+            raise Saturated
+        self._waiting += 1
+        try:
+            start = time.monotonic()
+            timeout = self._max_wait_seconds if self._max_wait_seconds > 0 else None
+            try:
+                await asyncio.wait_for(self._semaphore.acquire(), timeout=timeout)
+            except TimeoutError:
+                raise StaleWork(time.monotonic() - start) from None
+            return time.monotonic() - start
+        finally:
+            self._waiting -= 1
+
+    def release(self) -> None:
+        self._semaphore.release()
+
+
+__all__ = ["AsyncBoundedGate", "BoundedGate", "Saturated", "StaleWork"]

--- a/src/skimmer/cache.py
+++ b/src/skimmer/cache.py
@@ -5,7 +5,12 @@ from diskcache import Cache
 from cachetools import LRUCache
 from PIL import Image
 
-from skimmer.config import IMAGE_CACHE_SIZE_MB, ROI_CACHE_SIZE_MB, CACHE_DIR
+from skimmer.config import (
+    CACHE_DIR,
+    IMAGE_CACHE_SIZE_MB,
+    ROI_CACHE_EVICTION_POLICY,
+    ROI_CACHE_SIZE_MB,
+)
 
 
 def generate_roi_cache_key(
@@ -58,7 +63,7 @@ class CacheController:
         self._roi_cache = Cache(
             CACHE_DIR,
             size_limit=ROI_CACHE_SIZE_MB * 1024**2,
-            eviction_policy="least-recently-used",
+            eviction_policy=ROI_CACHE_EVICTION_POLICY,
         )
         self._roi_cache.expire()  # Ensure expired items are removed
 

--- a/src/skimmer/config.py
+++ b/src/skimmer/config.py
@@ -1,9 +1,18 @@
-from os import getenv
+from os import cpu_count, getenv
 from pathlib import Path
 
 # Configure image and ROI cache sizes
 IMAGE_CACHE_SIZE_MB = int(getenv("IMAGE_CACHE_SIZE_MB", 100))
 ROI_CACHE_SIZE_MB = int(getenv("ROI_CACHE_SIZE_MB", 100))
+
+# diskcache's "least-recently-used" policy writes to SQLite (bumping
+# access_time) on every read, not just writes -- under concurrent load this
+# serializes on SQLite's single-writer lock and dominates tail latency.
+# "least-recently-stored" needs no write on read (orders eviction by
+# store_time instead), trading LRU precision for read throughput -- a good
+# trade once the cache is sized to hold the working set (ROI_CACHE_SIZE_MB)
+# so eviction is rare either way.
+ROI_CACHE_EVICTION_POLICY = getenv("ROI_CACHE_EVICTION_POLICY", "least-recently-stored")
 
 # Configure filesystem cache directory
 CACHE_DIR = Path(getenv("CACHE_DIR", "/tmp/skimmer_cache"))
@@ -12,3 +21,10 @@ CACHE_DIR.mkdir(parents=True, exist_ok=True)
 # Configure Beholder client parameters
 BEHOLDER_URL = getenv("BEHOLDER_URL")
 BEHOLDER_API_KEY = getenv("BEHOLDER_API_KEY")
+
+# Bounded concurrency gate for crop generation (see skimmer/backpressure.py),
+# mirroring Beholder's beholder.capture.{threads,queuesize,maxwait}.
+# 0 = auto (a small multiple of the CPU count).
+CROP_POOL_SLOTS = int(getenv("CROP_POOL_SLOTS", 0)) or max(2, (cpu_count() or 4) // 2)
+CROP_POOL_QUEUE_SIZE = int(getenv("CROP_POOL_QUEUE_SIZE", 0)) or CROP_POOL_SLOTS * 8
+CROP_POOL_MAX_WAIT_SECONDS = float(getenv("CROP_POOL_MAX_WAIT_SECONDS", 15.0))

--- a/src/skimmer/constants.py
+++ b/src/skimmer/constants.py
@@ -3,5 +3,5 @@ Application constants
 """
 
 APP_NAME = "skimmer"
-APP_VERSION = "0.3.2"
+APP_VERSION = "0.4.0"
 APP_DESCRIPTION = "ROI Service"

--- a/src/skimmer/core.py
+++ b/src/skimmer/core.py
@@ -3,8 +3,15 @@ from io import BytesIO
 from beholder_client import BeholderClient
 from PIL import Image
 
+from skimmer.backpressure import AsyncBoundedGate, BoundedGate
 from skimmer.cache import CacheController, CachedROI, generate_roi_cache_key
-from skimmer.config import BEHOLDER_API_KEY, BEHOLDER_URL
+from skimmer.config import (
+    BEHOLDER_API_KEY,
+    BEHOLDER_URL,
+    CROP_POOL_MAX_WAIT_SECONDS,
+    CROP_POOL_QUEUE_SIZE,
+    CROP_POOL_SLOTS,
+)
 from skimmer.exceptions import BeholderNotConfiguredError, InvalidURLError
 from skimmer.utils import is_url_video, is_valid_url, validate_crop_parameters
 
@@ -22,6 +29,18 @@ class Skimmer:
         # Persistent client for connection pooling/keep-alive across requests
         self._http_client = httpx.Client(
             follow_redirects=True, verify=False, timeout=HTTP_TIMEOUT
+        )
+
+        # Bounds concurrent crop generation the same way Beholder bounds
+        # concurrent ffmpeg captures, so overload sheds load (503) instead of
+        # degrading into unbounded tail latency. Only one of these is ever
+        # exercised in a given process (Flask uses the sync gate, FastAPI the
+        # async one), so having both instantiated is harmless.
+        self._crop_gate = BoundedGate(
+            CROP_POOL_SLOTS, CROP_POOL_QUEUE_SIZE, CROP_POOL_MAX_WAIT_SECONDS
+        )
+        self._crop_gate_async = AsyncBoundedGate(
+            CROP_POOL_SLOTS, CROP_POOL_QUEUE_SIZE, CROP_POOL_MAX_WAIT_SECONDS
         )
 
     def fetch_image(self, url: str) -> Image.Image:
@@ -114,6 +133,8 @@ class Skimmer:
         Raises:
             InvalidURLError: If the URL is invalid.
             InvalidCropParametersError: If the crop coordinates or timestamp are invalid.
+            skimmer.backpressure.Saturated: If the crop pool has no room left.
+            skimmer.backpressure.StaleWork: If the request waited too long for a slot.
         """
         if not is_valid_url(url):
             raise InvalidURLError(f"Invalid URL: {url}")
@@ -130,32 +151,38 @@ class Skimmer:
             )
             return roi
 
-        # Fetch the image or video frame
-        if is_url_video(url):
-            image = self.fetch_video_frame(url, ms)
-        else:
-            image = self.fetch_image(url)
+        # Only misses (the actual fetch/encode work) go through the bounded
+        # gate; a cache hit above is cheap and shouldn't be throttled by it.
+        self._crop_gate.acquire()
+        try:
+            # Fetch the image or video frame
+            if is_url_video(url):
+                image = self.fetch_video_frame(url, ms)
+            else:
+                image = self.fetch_image(url)
 
-        # Crop
-        with image:  # ensure image is closed after use
-            cropped_image = image.crop((left, top, right, bottom))
+            # Crop
+            with image:  # ensure image is closed after use
+                cropped_image = image.crop((left, top, right, bottom))
 
-            # Convert to byte array
-            with BytesIO() as img_byte_arr:
-                cropped_image.save(img_byte_arr, format="PNG")
-                img_data = img_byte_arr.getvalue()
+                # Convert to byte array
+                with BytesIO() as img_byte_arr:
+                    cropped_image.save(img_byte_arr, format="PNG")
+                    img_data = img_byte_arr.getvalue()
 
-        # Cache
-        roi = CachedROI(img_data)
-        roi.headers["X-Cache"] = "MISS"
-        # Add client-side caching headers
-        roi.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-        roi.headers["ETag"] = (
-            f'"{generate_roi_cache_key(url, left, top, right, bottom, ms)}"'
-        )
-        self._cache.set_roi(roi, url, left, top, right, bottom, ms=ms)
+            # Cache
+            roi = CachedROI(img_data)
+            roi.headers["X-Cache"] = "MISS"
+            # Add client-side caching headers
+            roi.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            roi.headers["ETag"] = (
+                f'"{generate_roi_cache_key(url, left, top, right, bottom, ms)}"'
+            )
+            self._cache.set_roi(roi, url, left, top, right, bottom, ms=ms)
 
-        return roi
+            return roi
+        finally:
+            self._crop_gate.release()
 
     async def fetch_image_async(self, url: str) -> Image.Image:
         """
@@ -248,6 +275,8 @@ class Skimmer:
         Raises:
             InvalidURLError: If the URL is invalid.
             InvalidCropParametersError: If the crop coordinates or timestamp are invalid.
+            skimmer.backpressure.Saturated: If the crop pool has no room left.
+            skimmer.backpressure.StaleWork: If the request waited too long for a slot.
         """
         if not is_valid_url(url):
             raise InvalidURLError(f"Invalid URL: {url}")
@@ -264,32 +293,38 @@ class Skimmer:
             )
             return roi
 
-        # Fetch the image or video frame
-        if is_url_video(url):
-            image = await self.fetch_video_frame_async(url, ms)
-        else:
-            image = await self.fetch_image_async(url)
+        # Only misses (the actual fetch/encode work) go through the bounded
+        # gate; a cache hit above is cheap and shouldn't be throttled by it.
+        await self._crop_gate_async.acquire()
+        try:
+            # Fetch the image or video frame
+            if is_url_video(url):
+                image = await self.fetch_video_frame_async(url, ms)
+            else:
+                image = await self.fetch_image_async(url)
 
-        # Crop
-        with image:  # ensure image is closed after use
-            cropped_image = image.crop((left, top, right, bottom))
+            # Crop
+            with image:  # ensure image is closed after use
+                cropped_image = image.crop((left, top, right, bottom))
 
-            # Convert to byte array
-            with BytesIO() as img_byte_arr:
-                cropped_image.save(img_byte_arr, format="PNG")
-                img_data = img_byte_arr.getvalue()
+                # Convert to byte array
+                with BytesIO() as img_byte_arr:
+                    cropped_image.save(img_byte_arr, format="PNG")
+                    img_data = img_byte_arr.getvalue()
 
-        # Cache
-        roi = CachedROI(img_data)
-        roi.headers["X-Cache"] = "MISS"
-        # Add client-side caching headers
-        roi.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-        roi.headers["ETag"] = (
-            f'"{generate_roi_cache_key(url, left, top, right, bottom, ms)}"'
-        )
-        self._cache.set_roi(roi, url, left, top, right, bottom, ms=ms)
+            # Cache
+            roi = CachedROI(img_data)
+            roi.headers["X-Cache"] = "MISS"
+            # Add client-side caching headers
+            roi.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            roi.headers["ETag"] = (
+                f'"{generate_roi_cache_key(url, left, top, right, bottom, ms)}"'
+            )
+            self._cache.set_roi(roi, url, left, top, right, bottom, ms=ms)
 
-        return roi
+            return roi
+        finally:
+            self._crop_gate_async.release()
 
     def clear_cache(self) -> None:
         """

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from skimmer.backpressure import AsyncBoundedGate, BoundedGate, Saturated, StaleWork
+
+
+def test_bounded_gate_allows_up_to_slots_concurrently():
+    gate = BoundedGate(slots=2, queue_size=4, max_wait_seconds=1.0)
+
+    gate.acquire()
+    gate.acquire()
+
+    # A third caller has to wait -- release from another thread after a short
+    # delay so we can observe it queued rather than raising immediately.
+    released = threading.Event()
+
+    def release_soon():
+        time.sleep(0.05)
+        released.set()
+        gate.release()
+
+    threading.Thread(target=release_soon).start()
+
+    waited = gate.acquire()
+    assert released.is_set()
+    assert waited >= 0.04
+
+
+def test_bounded_gate_raises_saturated_when_queue_is_full():
+    gate = BoundedGate(slots=1, queue_size=1, max_wait_seconds=5.0)
+    gate.acquire()  # fills the only slot
+
+    # One caller can queue (queue_size=1); park it on a thread so it's really waiting.
+    waiter_started = threading.Event()
+
+    def wait_forever():
+        waiter_started.set()
+        gate.acquire()
+
+    t = threading.Thread(target=wait_forever, daemon=True)
+    t.start()
+    waiter_started.wait()
+    time.sleep(0.05)  # let the waiter actually register itself as queued
+
+    with pytest.raises(Saturated):
+        gate.acquire()
+
+
+def test_bounded_gate_raises_stale_work_after_max_wait():
+    gate = BoundedGate(slots=1, queue_size=4, max_wait_seconds=0.05)
+    gate.acquire()  # never released within the test
+
+    with pytest.raises(StaleWork):
+        gate.acquire()
+
+
+@pytest.mark.asyncio
+async def test_async_bounded_gate_allows_up_to_slots_concurrently():
+    gate = AsyncBoundedGate(slots=2, queue_size=4, max_wait_seconds=1.0)
+
+    await gate.acquire()
+    await gate.acquire()
+    gate.release()
+
+    waited = await gate.acquire()
+    assert waited >= 0
+
+
+@pytest.mark.asyncio
+async def test_async_bounded_gate_raises_stale_work_after_max_wait():
+    gate = AsyncBoundedGate(slots=1, queue_size=4, max_wait_seconds=0.05)
+    await gate.acquire()  # never released within the test
+
+    with pytest.raises(StaleWork):
+        await gate.acquire()

--- a/tests/test_skimmer.py
+++ b/tests/test_skimmer.py
@@ -1,11 +1,20 @@
 import shutil
 
+import httpx
 import pytest
 from PIL import Image
 
 from skimmer import create_default_flask_app, Skimmer
 from skimmer.cache import CachedROI, generate_roi_cache_key
 from skimmer.config import CACHE_DIR
+
+
+def _beholder_503(retry_after: str | None = "2.5") -> httpx.HTTPStatusError:
+    """Build the error beholder_client raises when Beholder itself sheds load."""
+    request = httpx.Request("POST", "https://beholder.example/capture")
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    response = httpx.Response(503, headers=headers, request=request)
+    return httpx.HTTPStatusError("busy", request=request, response=response)
 
 
 @pytest.fixture
@@ -284,6 +293,47 @@ def test_unexpected_error(client, mocker):
     response = client.get(f"/crop?url={url}&left=10&top=10&right=100&bottom=100")
     assert response.status_code == 500
     assert response.json == {"error": "An unexpected error occurred: Unexpected error"}
+
+
+def test_beholder_503_is_forwarded_as_skimmer_503(client, mocker):
+    """A 503 from Beholder (via beholder_client) must surface as Skimmer's own 503,
+    not the generic 500 catch-all, so callers can retry with the right Retry-After."""
+    url = "https://example.com/video.mp4"
+    mocker.patch(
+        "skimmer.core.Skimmer.generate_crop", side_effect=_beholder_503("2.5")
+    )
+
+    response = client.get(
+        f"/crop?url={url}&left=10&top=10&right=100&bottom=100&ms=1000"
+    )
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "2.5"
+
+
+def test_beholder_503_without_retry_after_falls_back_to_default(client, mocker):
+    mocker.patch(
+        "skimmer.core.Skimmer.generate_crop", side_effect=_beholder_503(None)
+    )
+
+    response = client.get(
+        "/crop?url=https://example.com/video.mp4&left=10&top=10&right=100&bottom=100&ms=1000"
+    )
+    assert response.status_code == 503
+    assert 1.0 <= float(response.headers["Retry-After"]) <= 3.0
+
+
+def test_beholder_non_503_error_is_not_treated_as_busy(client, mocker):
+    request = httpx.Request("POST", "https://beholder.example/capture")
+    error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(500, request=request)
+    )
+    mocker.patch("skimmer.core.Skimmer.generate_crop", side_effect=error)
+
+    response = client.get(
+        "/crop?url=https://example.com/video.mp4&left=10&top=10&right=100&bottom=100&ms=1000"
+    )
+    assert response.status_code == 500
+    assert "Retry-After" not in response.headers
 
 
 def test_fetch_image_with_redirect(mocker):


### PR DESCRIPTION
- ROI cache eviction: least-recently-used (writes to sqlite on every read) → least-recently-stored
- bound concurrent crop generation, shed load with 503 instead of unbounded tail latency (mirrors beholder's BoundedExecutor)
- forward Beholder's 503 as Skimmer's own 503 instead of a generic 500